### PR TITLE
Add CSRF protection to POST endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Python(Starlette) 백엔드 + Vanilla JS 프론트엔드, SQLite, Gemini/Ollama 
 ### Phase 2: 인증/보안
 - [x] **비밀번호 해싱**: PIN 평문 비교(`db.py:129`) → bcrypt
 - [x] **세션 보안 강화**: 쿠키에 `secure`, `httponly`, `samesite` 플래그 추가
-- [ ] **CSRF 토큰**: POST 엔드포인트 보호
+- [x] **CSRF 토큰**: POST 엔드포인트 보호
 - [ ] **회원가입/인증 플로우**: 이메일 인증 또는 OAuth 추가
 
 ### Phase 3: LLM 비용 관리

--- a/templates/index.html
+++ b/templates/index.html
@@ -815,6 +815,13 @@ function connectSSE() {
     const data = JSON.parse(e.data);
     handleScaffoldReady(data);
   });
+  eventSource.addEventListener("input_error", (e) => {
+    const data = JSON.parse(e.data);
+    document.getElementById("answer-input").disabled = false;
+    document.getElementById("submit-btn").disabled = false;
+    document.getElementById("answer-input").focus();
+    alert(data.message);
+  });
   eventSource.addEventListener("error_msg", (e) => {
     const data = JSON.parse(e.data);
     alert("Error: " + data.message);

--- a/templates/index.html
+++ b/templates/index.html
@@ -619,6 +619,25 @@ function buildStyleGrids() {
   });
 }
 
+// ===== CSRF =====
+function getCsrfToken() {
+  const m = document.cookie.match(/(?:^|;\s*)csrf_token=([^;]*)/);
+  return m ? m[1] : "";
+}
+function postJson(url, body) {
+  return fetch(url, {
+    method: "POST",
+    headers: {"Content-Type":"application/json", "X-CSRF-Token": getCsrfToken()},
+    body: JSON.stringify(body)
+  });
+}
+function postEmpty(url) {
+  return fetch(url, {
+    method: "POST",
+    headers: {"X-CSRF-Token": getCsrfToken()}
+  });
+}
+
 // ===== Session =====
 async function checkSession() {
   try {
@@ -665,11 +684,7 @@ function showPinModal(user) {
 async function submitPin() {
   const pin = document.getElementById("pin-input").value;
   if (pin.length !== 4) { document.getElementById("pin-error").textContent = "Enter 4 digits"; return; }
-  const r = await fetch("/api/login", {
-    method: "POST",
-    headers: {"Content-Type":"application/json"},
-    body: JSON.stringify({student_id: loginStudentId, pin})
-  });
+  const r = await postJson("/api/login", {student_id: loginStudentId, pin});
   if (r.ok) {
     const data = await r.json();
     closeModal("pin-modal");
@@ -700,11 +715,7 @@ async function submitSetup() {
   if (!name) { document.getElementById("setup-error").textContent = "Enter your name"; return; }
   if (pin.length !== 4 || !/^\d{4}$/.test(pin)) { document.getElementById("setup-error").textContent = "PIN must be 4 digits"; return; }
   if (!setupGrade) { document.getElementById("setup-error").textContent = "Pick your grade"; return; }
-  const r = await fetch("/api/setup", {
-    method: "POST",
-    headers: {"Content-Type":"application/json"},
-    body: JSON.stringify({name, pin, grade: setupGrade, curriculum_style: setupStyle})
-  });
+  const r = await postJson("/api/setup", {name, pin, grade: setupGrade, curriculum_style: setupStyle});
   if (r.ok) {
     const data = await r.json();
     closeModal("setup-modal");
@@ -762,11 +773,7 @@ async function saveSettings() {
   }
   const body = {name, grade: settingsGrade, curriculum_style: settingsStyle};
   if (pin) body.pin = pin;
-  const r = await fetch("/api/setup", {
-    method: "POST",
-    headers: {"Content-Type":"application/json"},
-    body: JSON.stringify(body)
-  });
+  const r = await postJson("/api/setup", body);
   if (r.ok) {
     const data = await r.json();
     currentStudent = data;
@@ -780,7 +787,7 @@ async function saveSettings() {
 
 // ===== Logout =====
 async function logout() {
-  await fetch("/api/logout", {method: "POST"});
+  await postEmpty("/api/logout");
   if (eventSource) { eventSource.close(); eventSource = null; }
   currentStudent = null;
   currentProblem = null;
@@ -865,11 +872,7 @@ async function newProblem() {
   document.getElementById("pipeline-steps").innerHTML = '<div style="text-align:center;padding:16px;color:#888;">Starting...</div>';
 
   const topic = selectedTopic === "Auto" ? null : selectedTopic;
-  await fetch("/api/new-problem", {
-    method: "POST",
-    headers: {"Content-Type":"application/json"},
-    body: JSON.stringify({topic})
-  });
+  await postJson("/api/new-problem", {topic});
 }
 
 function showProblem(data) {
@@ -917,17 +920,13 @@ async function submitAnswer() {
   document.getElementById("pipeline-card").style.display = "block";
   updatePipeline({agents: [{key:"helper", status:"working"}]});
 
-  await fetch("/api/submit-answer", {
-    method: "POST",
-    headers: {"Content-Type":"application/json"},
-    body: JSON.stringify({answer: val})
-  });
+  await postJson("/api/submit-answer", {answer: val});
 }
 
 async function skipProblem() {
   document.getElementById("answer-input").disabled = true;
   document.getElementById("submit-btn").disabled = true;
-  const r = await fetch("/api/skip", {method: "POST"});
+  const r = await postEmpty("/api/skip");
   const skipData = await r.json();
   const feedbackData = {is_correct: false, correct_answer: currentProblem?.correct_answer, feedback: "Skipped! The answer was " + (currentProblem?.correct_answer || "?") + ". Let's try another one!", skipped: true};
   showFeedback(feedbackData);
@@ -961,11 +960,7 @@ async function requestScaffold() {
   document.getElementById("pipeline-card").style.display = "block";
   document.getElementById("pipeline-steps").innerHTML = '<div style="text-align:center;padding:16px;color:#888;">Preparing practice problem...</div>';
 
-  await fetch("/api/scaffold-problem", {
-    method: "POST",
-    headers: {"Content-Type":"application/json"},
-    body: JSON.stringify({})
-  });
+  await postJson("/api/scaffold-problem", {});
 }
 
 function showFeedback(data) {

--- a/web_tutor.py
+++ b/web_tutor.py
@@ -15,7 +15,10 @@ warnings.filterwarnings("ignore")
 from dotenv import load_dotenv
 load_dotenv()
 
+import secrets
 from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.routing import Route
 from starlette.responses import HTMLResponse, JSONResponse
 from starlette.requests import Request
@@ -67,6 +70,26 @@ def _set_cookie(resp, key, value, max_age=86400*30):
     resp.set_cookie(key, value, max_age=max_age,
                     httponly=True, samesite="lax",
                     secure=SECURE_COOKIES)
+
+CSRF_SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
+
+class CSRFMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        csrf_token = request.cookies.get("csrf_token")
+        if not csrf_token:
+            csrf_token = secrets.token_hex(32)
+
+        if request.method not in CSRF_SAFE_METHODS:
+            header_token = request.headers.get("x-csrf-token", "")
+            if not csrf_token or header_token != csrf_token:
+                return JSONResponse({"error": "CSRF token mismatch"}, status_code=403)
+
+        response = await call_next(request)
+        # Set csrf_token cookie (NOT httponly — JS needs to read it)
+        response.set_cookie("csrf_token", csrf_token, max_age=86400*30,
+                            httponly=False, samesite="lax",
+                            secure=SECURE_COOKIES)
+        return response
 try:
     if USE_LOCAL:
         local_llm = LLM(model="ollama/gemma3:4b", base_url="http://localhost:11434")
@@ -1006,7 +1029,7 @@ routes = [
     Route("/api/events", api_events),
 ]
 
-app = Starlette(routes=routes)
+app = Starlette(routes=routes, middleware=[Middleware(CSRFMiddleware)])
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary
- Add `CSRFMiddleware` using double-submit cookie pattern
- CSRF token stored in non-httponly cookie (JS readable), verified via `X-CSRF-Token` header
- Add `postJson()` / `postEmpty()` frontend helpers that auto-include CSRF token
- All 7 POST endpoints now protected: login, setup, logout, new-problem, submit-answer, skip, scaffold-problem

## Test plan
- [x] Manual: login, create student, solve problems — all POST flows work
- [x] Manual: send POST without CSRF header via curl → should get 403
- [x] Verify csrf_token cookie appears in browser DevTools

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)